### PR TITLE
Refactoring generatie webcomponent

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -1,99 +1,20 @@
-const readline = require('readline').createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
-
+const {initializeWebcomponent} = require('./util/cloneUtils');
 const path = require('path');
-const fs = require('fs');
 
-readline.question(`Wat is de naam van de nieuwe webcomponent (prefix webcomponent-vl-ui- wordt automatisch toegevoegd)? `, (naam) => {
-  readline.question(`Wat is de description van de component? `, (description) => {
-    const currentPath = process.cwd();
-    const defaultPath = path.resolve(currentPath, '../webcomponent-vl-ui-' + naam);
-    readline.question(`Waar mag het project opgeslagen worden? [${defaultPath}]: `, (path) => {
-      initializeWebcomponent({
-        naam: naam,
-        description: description,
-        path: path ? path : defaultPath,
-      });
-      readline.close();
-    });
-  });
-});
+const currentPath = process.cwd();
 
-function initializeWebcomponent(options) {
-  copyFolderSync(process.cwd(), options.path, ['.git', 'node_modules', 'util', 'README.md', 'clone.sh', 'clone.js', 'package-lock.json']);
-  replaceDescriptionInReadMe(path.resolve(options.path, 'README.md.template'), options.description);
-  replaceDescriptionInPackageJson(path.resolve(options.path, 'package.json'), options.description);
-  replaceInFile(path.resolve(options.path, 'package.json'), options.naam);
-  replaceInFile(path.resolve(options.path, 'src/vl-blueprint.js'), options.naam);
-  replaceInFile(path.resolve(options.path, 'src/style.scss'), options.naam);
-  replaceInFile(path.resolve(options.path, 'README.md.template'), options.naam);
-  replaceInFile(path.resolve(options.path, 'index.js'), options.naam);
-  replaceInFile(path.resolve(options.path, 'src/index.js'), options.naam);
+const argv = require('yargs')
+    .usage('Usage: $0 --name [string] --description [string] --path [string]')
+    .command('run.js', 'Genereer boilerplate code voor een nieuwe webcomponent')
+    .demandOption(['name', 'description'])
+    .alias('name', 'n')
+    .alias('description', 'd')
+    .alias('path', 'p')
+    .describe('name', 'Naam van de te genereren webcomponent')
+    .describe('description', 'Omschrijving van de nieuwe component (description in package.json)')
+    .describe('path', 'Locatie v/d component')
+    .default('path', path.resolve(currentPath, '../'))
+    .argv;
 
-  replaceInFile(path.resolve(options.path, 'bamboo-specs/bamboo.yml'), options.naam);
-  replaceInFile(path.resolve(options.path, 'demo/vl-blueprint.html'), options.naam);
-  replaceInFile(path.resolve(options.path, 'test/e2e/components/vl-blueprint.js'), options.naam);
-  replaceInFile(path.resolve(options.path, 'test/e2e/pages/vl-blueprint.page.js'), options.naam);
-  replaceInFile(path.resolve(options.path, 'test/e2e/blueprint.test.js'), options.naam);
-  replaceInFile(path.resolve(options.path, 'test/unit/vl-blueprint.test.html'), options.naam);
-
-  rename(path.resolve(options.path, 'src/vl-blueprint.js'), path.resolve(options.path, `src/vl-${options.naam}.js`));
-  rename(path.resolve(options.path, 'README.md.template'), path.resolve(options.path, 'README.md'));
-
-  rename(path.resolve(options.path, 'demo/vl-blueprint.html'), path.resolve(options.path, `demo/vl-${options.naam}.html`));
-  rename(path.resolve(options.path, 'test/e2e/components/vl-blueprint.js'), path.resolve(options.path, `test/e2e/components/vl-${options.naam}.js`));
-  rename(path.resolve(options.path, 'test/e2e/pages/vl-blueprint.page.js'), path.resolve(options.path, `test/e2e/pages/vl-${options.naam}.page.js`));
-  rename(path.resolve(options.path, 'test/e2e/blueprint.test.js'), path.resolve(options.path, `test/e2e/${options.naam}.test.js`));
-  rename(path.resolve(options.path, 'test/unit/vl-blueprint.test.html'), path.resolve(options.path, `test/unit/vl-${options.naam}.test.html`));
-}
-
-function replaceDescriptionInReadMe(path, description) {
-  replace(path, '@description@', description);
-}
-
-function replaceDescriptionInPackageJson(path, description) {
-  const data = fs.readFileSync(path, 'utf8');
-  const packageJsonData = JSON.parse(data);
-  packageJsonData.description = description;
-  const result = JSON.stringify(packageJsonData, null, '\t');
-  fs.writeFileSync(path, result, 'utf8');
-}
-
-function replaceInFile(path, naam) {
-  const naamLowercase = naam.toLowerCase();
-  const naamCamelcaseZonderDashes = naamLowercase.replace(/(^|[\s-])\S/g, function(match) {
-    return match.toUpperCase();
-  }).replace(/-/g, '');
-  const naamUppercaseZonderDashes = naamLowercase.toUpperCase().replace(/-/g, '');
-  const data = fs.readFileSync(path, 'utf8');
-  let result = data;
-  result = result.replace(/blueprint/g, naamLowercase);
-  result = result.replace(/Blueprint/g, naamCamelcaseZonderDashes);
-  result = result.replace(/BLUEPRINT/g, naamUppercaseZonderDashes);
-  fs.writeFileSync(path, result, 'utf8');
-}
-
-function rename(src, dest) {
-  fs.renameSync(src, dest);
-}
-
-function replace(someFile, search, replacement) {
-  const data = fs.readFileSync(someFile, 'utf8');
-  const result = data.replace(search, replacement);
-  fs.writeFileSync(someFile, result, 'utf8');
-}
-
-function copyFolderSync(from, to, exclusions) {
-  fs.mkdirSync(to);
-  fs.readdirSync(from).forEach((element) => {
-    if (!exclusions.includes(element)) {
-      if (fs.lstatSync(path.join(from, element)).isFile()) {
-        fs.copyFileSync(path.join(from, element), path.join(to, element));
-      } else {
-        copyFolderSync(path.join(from, element), path.join(to, element), exclusions);
-      }
-    }
-  });
-}
+initializeWebcomponent({'name': argv.name, 'description': argv.description, 'path': argv.path});
+console.log(`Webcomponent ${argv.name} aangemaakt in ${argv.path}`);

--- a/clone.sh
+++ b/clone.sh
@@ -1,1 +1,0 @@
-node clone.js

--- a/util/cloneUtils.js
+++ b/util/cloneUtils.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const path = require('path');
+
+function initializeWebcomponent(options) {
+  const savePath = getSavePath(options);
+  copyFolderSync(process.cwd(), savePath, ['.git', 'node_modules', 'util', 'README.md', 'clone.sh', 'clone.js', 'package-lock.json']);
+  replaceDescriptionInReadMe(path.resolve(savePath, 'README.md.template'), options.description);
+  replaceDescriptionInPackageJson(path.resolve(savePath, 'package.json'), options.description);
+  replaceInFile(path.resolve(savePath, 'package.json'), options.name);
+  replaceInFile(path.resolve(savePath, 'src/vl-blueprint.js'), options.name);
+  replaceInFile(path.resolve(savePath, 'src/style.scss'), options.name);
+  replaceInFile(path.resolve(savePath, 'README.md.template'), options.name);
+  replaceInFile(path.resolve(savePath, 'index.js'), options.name);
+  replaceInFile(path.resolve(savePath, 'src/index.js'), options.name);
+
+  replaceInFile(path.resolve(savePath, 'bamboo-specs/bamboo.yml'), options.name);
+  replaceInFile(path.resolve(savePath, 'demo/vl-blueprint.html'), options.name);
+  replaceInFile(path.resolve(savePath, 'test/e2e/components/vl-blueprint.js'), options.name);
+  replaceInFile(path.resolve(savePath, 'test/e2e/pages/vl-blueprint.page.js'), options.name);
+  replaceInFile(path.resolve(savePath, 'test/e2e/blueprint.test.js'), options.name);
+  replaceInFile(path.resolve(savePath, 'test/unit/vl-blueprint.test.html'), options.name);
+
+  rename(path.resolve(savePath, 'src/vl-blueprint.js'), path.resolve(savePath, `src/vl-${options.name}.js`));
+  rename(path.resolve(savePath, 'README.md.template'), path.resolve(savePath, 'README.md'));
+
+  rename(path.resolve(savePath, 'demo/vl-blueprint.html'), path.resolve(savePath, `demo/vl-${options.name}.html`));
+  rename(path.resolve(savePath, 'test/e2e/components/vl-blueprint.js'), path.resolve(savePath, `test/e2e/components/vl-${options.name}.js`));
+  rename(path.resolve(savePath, 'test/e2e/pages/vl-blueprint.page.js'), path.resolve(savePath, `test/e2e/pages/vl-${options.name}.page.js`));
+  rename(path.resolve(savePath, 'test/e2e/blueprint.test.js'), path.resolve(savePath, `test/e2e/${options.name}.test.js`));
+  rename(path.resolve(savePath, 'test/unit/vl-blueprint.test.html'), path.resolve(savePath, `test/unit/vl-${options.name}.test.html`));
+}
+
+function getSavePath(options) {
+  return path.join(options.path, `webcomponent-vl-ui-${options.name}`);
+}
+
+function replaceDescriptionInReadMe(path, description) {
+  replace(path, '@description@', description);
+}
+
+function replaceDescriptionInPackageJson(path, description) {
+  const data = fs.readFileSync(path, 'utf8');
+  const packageJsonData = JSON.parse(data);
+  packageJsonData.description = description;
+  const result = JSON.stringify(packageJsonData, null, '\t');
+  fs.writeFileSync(path, result, 'utf8');
+}
+
+function replaceInFile(path, name) {
+  const nameLowercase = name.toLowerCase();
+  const nameCamelcaseZonderDashes = nameLowercase.replace(/(^|[\s-])\S/g, function(match) {
+    return match.toUpperCase();
+  }).replace(/-/g, '');
+  const nameUppercaseZonderDashes = nameLowercase.toUpperCase().replace(/-/g, '');
+  const data = fs.readFileSync(path, 'utf8');
+  let result = data;
+  result = result.replace(/blueprint/g, nameLowercase);
+  result = result.replace(/Blueprint/g, nameCamelcaseZonderDashes);
+  result = result.replace(/BLUEPRINT/g, nameUppercaseZonderDashes);
+  fs.writeFileSync(path, result, 'utf8');
+}
+
+function rename(src, dest) {
+  fs.renameSync(src, dest);
+}
+
+function replace(someFile, search, replacement) {
+  const data = fs.readFileSync(someFile, 'utf8');
+  const result = data.replace(search, replacement);
+  fs.writeFileSync(someFile, result, 'utf8');
+}
+
+function copyFolderSync(from, to, exclusions) {
+  fs.mkdirSync(to);
+  fs.readdirSync(from).forEach((element) => {
+    if (!exclusions.includes(element)) {
+      if (fs.lstatSync(path.join(from, element)).isFile()) {
+        fs.copyFileSync(path.join(from, element), path.join(to, element));
+      } else {
+        copyFolderSync(path.join(from, element), path.join(to, element), exclusions);
+      }
+    }
+  });
+}
+
+module.exports = {initializeWebcomponent};


### PR DESCRIPTION
Het genereren van een nieuwe webcomponent via blueprint kan nu volledig geautomatiseerd gebeuren via CLI.
Wanneer `node clone.js` zonder parameters aangeroepen word, zal er toegelicht worden welke parameters er
allemaal verwacht worden, alsook de default values.